### PR TITLE
Add multiple control types for controls menu

### DIFF
--- a/SCENES/GUI/controls_screen.tscn
+++ b/SCENES/GUI/controls_screen.tscn
@@ -1,7 +1,13 @@
-[gd_scene load_steps=3 format=3 uid="uid://c6tdu4r5v8bbs"]
+[gd_scene load_steps=7 format=3 uid="uid://c6tdu4r5v8bbs"]
 
 [ext_resource type="Script" path="res://SCRIPTS/controls_screen.gd" id="1_tvbxo"]
+[ext_resource type="Script" path="res://SCRIPTS/controls_tab_container.gd" id="2_pnoft"]
 [ext_resource type="StyleBox" uid="uid://1mss4twkxib3" path="res://button_box.tres" id="2_tn6xa"]
+[ext_resource type="Texture2D" uid="uid://bsnl2lvtbxral" path="res://ASSETS/Art/joystick/Joystick.png" id="3_1l55u"]
+[ext_resource type="Texture2D" uid="uid://b4n6irf1jephl" path="res://icon.svg" id="4_lo2b3"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vwyni"]
+bg_color = Color(0.255659, 0.255659, 0.255659, 1)
 
 [node name="HowToPlayScreen" type="Control"]
 custom_minimum_size = Vector2(640, 360)
@@ -61,38 +67,51 @@ theme_override_font_sizes/font_size = 24
 text = "Player Controls"
 horizontal_alignment = 1
 
-[node name="Controls" type="HBoxContainer" parent="ScreenRows/PlayerControl"]
+[node name="ControlsTabContainer" type="TabContainer" parent="ScreenRows/PlayerControl"]
+custom_minimum_size = Vector2(320, 190)
 layout_mode = 2
+size_flags_horizontal = 4
+theme_override_styles/panel = SubResource("StyleBoxFlat_vwyni")
+tab_alignment = 1
+current_tab = 0
+script = ExtResource("2_pnoft")
 
-[node name="SpacerRight" type="Control" parent="ScreenRows/PlayerControl/Controls"]
+[node name="Keyboard + Mouse" type="HBoxContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer"]
+layout_mode = 2
+alignment = 1
+metadata/_tab_index = 0
+
+[node name="SpacerRight" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ControlsGrid" type="GridContainer" parent="ScreenRows/PlayerControl/Controls"]
+[node name="ControlsGrid" type="GridContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse"]
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
 theme_override_constants/h_separation = 16
 theme_override_constants/v_separation = 16
 columns = 2
 
-[node name="Control1Name" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control1Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "Key map example"
 
-[node name="Control1Grid" type="GridContainer" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control1Grid" type="GridContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 layout_mode = 2
 size_flags_horizontal = 0
 theme_override_constants/h_separation = 4
 theme_override_constants/v_separation = 4
 columns = 3
 
-[node name="ControlValue" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 horizontal_alignment = 1
 
-[node name="ControlValue2" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue2" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -100,13 +119,13 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "W"
 horizontal_alignment = 1
 
-[node name="ControlValue3" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue3" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 horizontal_alignment = 1
 
-[node name="ControlValue4" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue4" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -114,7 +133,7 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "A"
 horizontal_alignment = 1
 
-[node name="ControlValue5" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue5" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -122,7 +141,7 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "S"
 horizontal_alignment = 1
 
-[node name="ControlValue6" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control1Grid"]
+[node name="ControlValue6" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control1Grid"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -130,12 +149,12 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "D"
 horizontal_alignment = 1
 
-[node name="Control2Name" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control2Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "Key press example"
 
-[node name="Control2Button" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control2Button" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 custom_minimum_size = Vector2(57, 16)
 layout_mode = 2
 size_flags_horizontal = 0
@@ -144,17 +163,17 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "Left Click"
 horizontal_alignment = 1
 
-[node name="Control3Name" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control3Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
 text = "Key combo example"
 
-[node name="Control3Combo" type="HBoxContainer" parent="ScreenRows/PlayerControl/Controls/ControlsGrid"]
+[node name="Control3Combo" type="HBoxContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid"]
 layout_mode = 2
 size_flags_horizontal = 0
 theme_override_constants/separation = 10
 
-[node name="ControlButton1" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control3Combo"]
+[node name="ControlButton1" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control3Combo"]
 custom_minimum_size = Vector2(61, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -162,7 +181,7 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "Right Click"
 horizontal_alignment = 1
 
-[node name="Plus" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control3Combo"]
+[node name="Plus" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control3Combo"]
 custom_minimum_size = Vector2(16, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -170,7 +189,7 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "+"
 horizontal_alignment = 1
 
-[node name="ControlButton2" type="Label" parent="ScreenRows/PlayerControl/Controls/ControlsGrid/Control3Combo"]
+[node name="ControlButton2" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse/ControlsGrid/Control3Combo"]
 custom_minimum_size = Vector2(57, 16)
 layout_mode = 2
 theme_override_font_sizes/font_size = 16
@@ -178,7 +197,214 @@ theme_override_styles/normal = ExtResource("2_tn6xa")
 text = "Left Click"
 horizontal_alignment = 1
 
-[node name="SpacerLeft" type="Control" parent="ScreenRows/PlayerControl/Controls"]
+[node name="SpacerLeft" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Keyboard + Mouse"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Mobile" type="HBoxContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer"]
+visible = false
+layout_mode = 2
+alignment = 1
+metadata/_tab_index = 1
+
+[node name="SpacerRight" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ControlsGrid" type="GridContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/h_separation = 16
+columns = 2
+
+[node name="Control1Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Joystick example"
+
+[node name="TextureRect" type="TextureRect" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+texture = ExtResource("3_1l55u")
+expand_mode = 3
+stretch_mode = 4
+
+[node name="Control2Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Button press example"
+
+[node name="TextureRect2" type="TextureRect" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("4_lo2b3")
+expand_mode = 3
+stretch_mode = 4
+
+[node name="Control3Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Button press example"
+
+[node name="TextureRect3" type="TextureRect" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile/ControlsGrid"]
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+size_flags_horizontal = 4
+texture = ExtResource("4_lo2b3")
+expand_mode = 3
+stretch_mode = 4
+
+[node name="SpacerLeft" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Mobile"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Controller" type="HBoxContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer"]
+visible = false
+layout_mode = 2
+metadata/_tab_index = 2
+
+[node name="SpacerRight" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ControlsGrid" type="GridContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/h_separation = 16
+theme_override_constants/v_separation = 16
+columns = 2
+
+[node name="Control1Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Button map example"
+
+[node name="Control1Grid" type="GridContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/h_separation = 4
+theme_override_constants/v_separation = 4
+columns = 3
+
+[node name="ControlValue" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
+[node name="ControlValue2" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "▲"
+horizontal_alignment = 1
+
+[node name="ControlValue3" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
+[node name="ControlValue4" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "◀"
+horizontal_alignment = 1
+
+[node name="ControlValue5" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
+[node name="ControlValue6" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "▶"
+horizontal_alignment = 1
+
+[node name="ControlValue7" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
+[node name="ControlValue8" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "▼"
+horizontal_alignment = 1
+
+[node name="ControlValue9" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control1Grid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 1
+
+[node name="Control2Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Button press example"
+
+[node name="Control2Button" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "B"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Control3Name" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Button combo example"
+
+[node name="Control3Combo" type="HBoxContainer" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid"]
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_constants/separation = 10
+
+[node name="Control2Button" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control3Combo"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "A"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Plus" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control3Combo"]
+custom_minimum_size = Vector2(16, 16)
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "+"
+horizontal_alignment = 1
+
+[node name="Control2Button2" type="Label" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller/ControlsGrid/Control3Combo"]
+custom_minimum_size = Vector2(24, 24)
+layout_mode = 2
+size_flags_horizontal = 0
+theme_override_font_sizes/font_size = 16
+theme_override_styles/normal = ExtResource("2_tn6xa")
+text = "X"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SpacerLeft" type="Control" parent="ScreenRows/PlayerControl/ControlsTabContainer/Controller"]
 layout_mode = 2
 size_flags_horizontal = 3
 

--- a/SCRIPTS/controls_tab_container.gd
+++ b/SCRIPTS/controls_tab_container.gd
@@ -1,0 +1,26 @@
+extends TabContainer
+
+enum Tabs {
+	KEYBOARD_AND_MOUSE,
+	MOBILE,
+	CONTROLLER,
+}
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	if OS.has_feature("web_android") or OS.has_feature("web_ios") or OS.has_feature("mobile"):
+		current_tab = Tabs.MOBILE
+	elif Globals.joypad_connected:
+		current_tab = Tabs.CONTROLLER
+	else:
+		current_tab = Tabs.KEYBOARD_AND_MOUSE
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		current_tab = Tabs.MOBILE
+	elif event is InputEventJoypadButton or event is InputEventJoypadMotion:
+		current_tab = Tabs.CONTROLLER


### PR DESCRIPTION
When showing the controls menu, if on mobile, show mobile controls, if not then if controller connected, show controller controls, if not then show keyboard and mouse controls.

Also allow choosing what control type shows by selecting the respective tab.

ALSO switch to controller or mobile controls if an input event from either is detected